### PR TITLE
Fix elevator callers above frames not being pressable

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/block/BlockElevatorCaller.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/BlockElevatorCaller.java
@@ -129,7 +129,7 @@ public class BlockElevatorCaller extends BlockPneumaticCraftCamo {
 
     public static void setSurroundingElevators(World world, BlockPos pos, int floor) {
         for (EnumFacing dir : EnumFacing.HORIZONTALS) {
-            TileEntityElevatorBase elevator = getElevatorBase(world, pos.offset(dir));
+            TileEntityElevatorBase elevator = getElevatorBase(world, pos.offset(dir).offset(EnumFacing.DOWN, 2));
             if (elevator != null) {
                 elevator.goToFloor(floor);
             }


### PR DESCRIPTION
The 2-level offset was missed here, so the callers don't send the message to move down if placed 2 blocks above the topmost frame. This prevents having the elevator move to the topmost position flush with the frame top.