### PR TITLE
Fixed all block faces being considered solid

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/block/BlockElevatorCaller.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/BlockElevatorCaller.java
@@ -4,6 +4,7 @@ import me.desht.pneumaticcraft.common.tileentity.TileEntityElevatorBase;
 import me.desht.pneumaticcraft.common.tileentity.TileEntityElevatorCaller;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -120,6 +121,12 @@ public class BlockElevatorCaller extends BlockPneumaticCraftCamo {
 
         setBlockBounds(FULL_BLOCK_AABB);
         return rayTrace;
+    }
+
+    @Override
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+        IBlockState camoState = getCamoState(worldIn, pos);
+        return camoState != null ? camoState.getBlockFaceShape(worldIn, pos, face) : BlockFaceShape.SOLID;
     }
 
     @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/block/BlockPneumaticCraftCamo.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/BlockPneumaticCraftCamo.java
@@ -9,6 +9,7 @@ import me.desht.pneumaticcraft.common.util.PneumaticCraftUtils;
 import me.desht.pneumaticcraft.common.util.PropertyObject;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -120,6 +121,12 @@ public abstract class BlockPneumaticCraftCamo extends BlockPneumaticCraftModeled
         // must not use a camouflageable block as camouflage!
         IBlockState camoState = ((ICamouflageableTE) te).getCamouflage();
         return camoState == null || camoState.getBlock() instanceof BlockPneumaticCraftCamo ? null : camoState;
+    }
+
+    @Override
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+        IBlockState camoState = getCamoState(worldIn, pos);
+        return camoState != null ? camoState.getBlockFaceShape(worldIn, pos, face) : BlockFaceShape.UNDEFINED;
     }
 
     @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/block/BlockPneumaticCraftModeled.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/BlockPneumaticCraftModeled.java
@@ -1,7 +1,11 @@
 package me.desht.pneumaticcraft.common.block;
 
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 
 public abstract class BlockPneumaticCraftModeled extends BlockPneumaticCraft {
 
@@ -17,5 +21,10 @@ public abstract class BlockPneumaticCraftModeled extends BlockPneumaticCraft {
     @Override
     public boolean isFullCube(IBlockState state) {
         return false;
+    }
+
+    @Override
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
+        return BlockFaceShape.UNDEFINED;
     }
 }


### PR DESCRIPTION
`BlockPneumaticCraftModeled::getBlockFaceShape` now returns `BlockFaceShape.UNDEFINED` and camo blocks if disguised get the value of the block they're disguised as, otherwise return `UNDEFINED`(the elevator caller is an exception, it returns `SOLID` if not desguised).