### PR TITLE
Add camera orientations for various items

### DIFF
--- a/src/main/resources/assets/pneumaticcraft/models/item/camo_applicator.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/camo_applicator.json
@@ -1,6 +1,28 @@
 {
-  "parent" : "item/generated",
   "textures" : {
     "layer0" : "pneumaticcraft:items/camo_applicator"
+  },
+  "parent" : "item/generated",
+  "display": {
+     "thirdperson_righthand": {
+       "rotation": [ 90, -90, 90 ],
+       "translation": [ 0, -1, -2 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+     },
+     "thirdperson_lefthand": {
+       "rotation": [ -90, 90, 90 ],
+       "translation": [ 0, -1, -2 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+     },
+     "firstperson_righthand": {
+       "rotation": [ 0, -90, 25 ],
+       "translation": [ -1.5, 1.5, 0],
+       "scale": [ 0.75, 0.75, 0.75 ]
+     },
+     "firstperson_lefthand": {
+       "rotation": [ 0, 90, -25 ],
+       "translation": [ -1.5, 1.5, 0],
+       "scale": [ 0.75, 0.75, 0.75 ]
+    }
   }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/gps_tool.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/gps_tool.json
@@ -1,6 +1,28 @@
 {
-   "parent" : "item/generated",
-   "textures" : {
-      "layer0" : "pneumaticcraft:items/gps_tool"
-   }
+  "parent" : "item/generated",
+  "textures" : {
+     "layer0" : "pneumaticcraft:items/gps_tool"
+  },
+  "display": {
+    "thirdperson_lefthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 0, 4, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "thirdperson_righthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 0, 4, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_lefthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 4, 1, -6],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_righthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 4, 1, -6],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    }
+  }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/logistics_configurator.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/logistics_configurator.json
@@ -1,6 +1,28 @@
 {
-   "textures" : {
-      "layer0" : "pneumaticcraft:items/logistics_configurator"
-   },
-   "parent" : "item/generated"
+  "textures" : {
+    "layer0" : "pneumaticcraft:items/logistics_configurator"
+  },
+  "parent" : "item/generated",
+  "display": {
+     "thirdperson_righthand": {
+       "rotation": [ 90, -90, 90 ],
+       "translation": [ 0, -1, -2 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+     },
+     "thirdperson_lefthand": {
+       "rotation": [ -90, 90, 90 ],
+       "translation": [ 0, -1, -2 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+     },
+     "firstperson_righthand": {
+       "rotation": [ 0, -90, 25 ],
+       "translation": [ -1.5, 1.5, 0],
+       "scale": [ 0.75, 0.75, 0.75 ]
+     },
+     "firstperson_lefthand": {
+       "rotation": [ 0, 90, -25 ],
+       "translation": [ -1.5, 1.5, 0],
+       "scale": [ 0.75, 0.75, 0.75 ]
+    }
+  }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/manometer.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/manometer.json
@@ -15,14 +15,14 @@
        "scale": [ 0.6, 0.6, 0.6 ]
     },
     "firstperson_lefthand": {
-       "rotation": [ 0, 180, 67.5 ],
-       "translation": [ 4, 0, -6],
-       "scale": [ 0.6, 0.6, 0.6 ]
+       "rotation": [ 20, 100, 10 ],
+       "translation": [ 4, -1, -6],
+       "scale": [ 0.75, 0.75, 0.75 ]
     },
     "firstperson_righthand": {
-       "rotation": [ 0, 0, -67.5 ],
-       "translation": [ 4, 0, -6],
-       "scale": [ 0.6, 0.6, 0.6 ]
+       "rotation": [ 20, -80, -10 ],
+       "translation": [ 4, -1, -6],
+       "scale": [ 0.75, 0.75, 0.75 ]
     }
   }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/manometer.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/manometer.json
@@ -1,6 +1,28 @@
 {
-   "textures" : {
-      "layer0" : "pneumaticcraft:items/manometer"
-   },
-   "parent" : "item/generated"
+  "textures" : {
+     "layer0" : "pneumaticcraft:items/manometer"
+  },
+  "parent" : "item/generated",
+  "display": {
+    "thirdperson_lefthand": {
+       "rotation": [ 0, 0, -45 ],
+       "translation": [ 0, -2, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "thirdperson_righthand": {
+       "rotation": [ 0, 0, 45 ],
+       "translation": [ 0, -2, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_lefthand": {
+       "rotation": [ 0, 180, 67.5 ],
+       "translation": [ 4, 0, -6],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_righthand": {
+       "rotation": [ 0, 0, -67.5 ],
+       "translation": [ 4, 0, -6],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    }
+  }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/pneumatic_wrench.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/pneumatic_wrench.json
@@ -1,6 +1,28 @@
 {
-   "textures" : {
-      "layer0" : "pneumaticcraft:items/pneumatic_wrench"
-   },
-   "parent" : "item/generated"
+  "textures" : {
+    "layer0" : "pneumaticcraft:items/pneumatic_wrench"
+  },
+  "parent" : "item/generated",
+  "display": {
+     "thirdperson_righthand": {
+       "rotation": [ 90, -90, 90 ],
+       "translation": [ 0, -1, -2 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+     },
+     "thirdperson_lefthand": {
+       "rotation": [ -90, 90, 90 ],
+       "translation": [ 0, -1, -2 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+     },
+     "firstperson_righthand": {
+       "rotation": [ 0, -90, 25 ],
+       "translation": [ -1.5, 1.5, 0],
+       "scale": [ 0.75, 0.75, 0.75 ]
+     },
+     "firstperson_lefthand": {
+       "rotation": [ 0, 90, -25 ],
+       "translation": [ -1.5, 1.5, 0],
+       "scale": [ 0.75, 0.75, 0.75 ]
+    }
+  }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/remote.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/remote.json
@@ -1,6 +1,28 @@
 {
-   "textures" : {
-      "layer0" : "pneumaticcraft:items/remote"
-   },
-   "parent" : "item/generated"
+  "textures" : {
+    "layer0" : "pneumaticcraft:items/remote"
+  },
+  "parent" : "item/generated",
+  "display": {
+    "thirdperson_lefthand": {
+       "rotation": [ 0, 0, -45 ],
+       "translation": [ 0, 4, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "thirdperson_righthand": {
+       "rotation": [ 0, 0, 45 ],
+       "translation": [ 0, 4, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_lefthand": {
+       "rotation": [ 0, 0, -45 ],
+       "translation": [ 4, 0, -6],
+       "scale": [ 0.5, 0.5, 0.5 ]
+    },
+    "firstperson_righthand": {
+       "rotation": [ 0, 0, 45 ],
+       "translation": [ 4, 0, -6],
+       "scale": [ 0.5, 0.5, 0.5 ]
+    }
+  }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/seismic_sensor.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/seismic_sensor.json
@@ -1,6 +1,29 @@
 {
-   "parent" : "item/generated",
-   "textures" : {
-      "layer0" : "pneumaticcraft:items/seismic_sensor"
-   }
+  "parent" : "item/generated",
+  "textures" : {
+     "layer0" : "pneumaticcraft:items/seismic_sensor"
+  },
+  "parent" : "item/generated",
+  "display": {
+    "thirdperson_lefthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 0, 4, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "thirdperson_righthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 0, 4, 0 ],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_lefthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 4, 1, -6],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    },
+    "firstperson_righthand": {
+       "rotation": [ 0, 0, 0 ],
+       "translation": [ 4, 1, -6],
+       "scale": [ 0.6, 0.6, 0.6 ]
+    }
+  }
 }

--- a/src/main/resources/assets/pneumaticcraft/models/item/seismic_sensor.json
+++ b/src/main/resources/assets/pneumaticcraft/models/item/seismic_sensor.json
@@ -3,7 +3,6 @@
   "textures" : {
      "layer0" : "pneumaticcraft:items/seismic_sensor"
   },
-  "parent" : "item/generated",
   "display": {
     "thirdperson_lefthand": {
        "rotation": [ 0, 0, 0 ],


### PR DESCRIPTION
Add `"display"` values for various handheld items, so they appear in logical orientations.

* Wrench, Camo Applicator and Logicstics Configurator are held like a drill.
* Manometer is held so the probe is pointing forwards.
* GPS tool, Seismic Sensor and Remote is held vertically.

![pneumaticcraft_orient](https://user-images.githubusercontent.com/8453732/36080951-f6c5155a-0f8f-11e8-9f87-5dfc42e5b6f8.png)
