### PR TITLE
Fix compatibility with forge 1.16.1-32.0.107

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.daemon=false
 # Minecraft versions
 #########################################################
 mc_version=1.16.1
-forge_version=32.0.98
+forge_version=32.0.107
 mappings_version=20200723-1.16.1
 
 #########################################################

--- a/src/main/java/me/desht/pneumaticcraft/client/ClientSetup.java
+++ b/src/main/java/me/desht/pneumaticcraft/client/ClientSetup.java
@@ -48,6 +48,7 @@ import net.minecraft.client.util.InputMappings;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemModelsProperties;
 import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.event.ParticleFactoryRegisterEvent;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.client.settings.KeyModifier;
@@ -75,6 +76,7 @@ public class ClientSetup {
     public static void initEarly() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientSetup::init);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientSetup::registerParticleFactories);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientSetup::registerModelLoaders);
     }
 
     static void init(FMLClientSetupEvent event) {
@@ -97,8 +99,6 @@ public class ClientSetup {
     }
 
     public static void initLate() {
-        modelInit();
-
         setBlockRenderLayers();
 
         registerItemModelProperties();
@@ -159,7 +159,7 @@ public class ClientSetup {
         }
     }
 
-    private static void modelInit() {
+    private static void registerModelLoaders(ModelRegistryEvent event) {
         ModelLoaderRegistry.registerLoader(RL("camouflaged"), CamouflageModel.Loader.INSTANCE);
         ModelLoaderRegistry.registerLoader(RL("pressure_glass"), PressureGlassModel.Loader.INSTANCE);
         ModelLoaderRegistry.registerLoader(RL("fluid_container_item"), FluidItemModel.Loader.INSTANCE);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,7 +18,7 @@ PneumaticCraft: Repressurized: doing cool stuff with compressed air.'''
 [[dependencies.pneumaticcraft]]
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[32.0.70,)" #mandatory
+    versionRange="[32.0.107,)" #mandatory
     ordering="NONE"
     side="BOTH"
 #[[dependencies.pneumaticcraft]]


### PR DESCRIPTION
Fixes crashes on latest Forge for 1.16.
`ModelLoadersRegistry.registerLoader` needs to be called in a specific spot now.