### PR TITLE
Update to 4.0.0 version of Immersive Engineering API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ crafttweaker_version=5.0.1.150
 patchouli_version=1.15.2-1.2-32.160
 botania_version=r1.15-383.376
 cc_tweaked_version=1.88.1
-immersive_engineering_version=0.15-108-0a1a37f1
+immersive_engineering_version=1.15.2-4.0.0-117
 # 1.15.2-9.10.8.421
 mekanism_curse_id=2981858
 # 1.10.8-B72_1.15.2

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/immersiveengineering/ImmersiveEngineering.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/immersiveengineering/ImmersiveEngineering.java
@@ -3,7 +3,7 @@ package me.desht.pneumaticcraft.common.thirdparty.immersiveengineering;
 import blusunrize.immersiveengineering.api.energy.DieselHandler;
 import me.desht.pneumaticcraft.api.PneumaticRegistry;
 import me.desht.pneumaticcraft.api.harvesting.HarvestHandler;
-import me.desht.pneumaticcraft.common.core.ModFluids;
+import me.desht.pneumaticcraft.common.PneumaticCraftTags;
 import me.desht.pneumaticcraft.common.harvesting.HarvestHandlerCactusLike;
 import me.desht.pneumaticcraft.common.thirdparty.IThirdParty;
 import me.desht.pneumaticcraft.lib.Log;
@@ -34,7 +34,7 @@ public class ImmersiveEngineering implements IThirdParty {
         MinecraftForge.EVENT_BUS.register(ElectricAttackHandler.class);
         IEHeatHandler.registerHeatHandler();
 
-        DieselHandler.registerFuel(ModFluids.DIESEL.get(), 125);  // equivalent to IE biodiesel
+        DieselHandler.registerFuel(PneumaticCraftTags.Fluids.DIESEL, 125);  // equivalent to IE biodiesel
 
         if (IE_BIODIESEL != null && IE_BIODIESEL != Fluids.EMPTY) {
             // equivalent to PNC:R diesel


### PR DESCRIPTION
This was done in 1.16, but also needs to be done in 1.15. Currently the handler fails due to the method type mismatch, so the diesel compatibility isn't applied.