### PR TITLE
Disenchanting Recipe for Enchanted Books with more than one enchantment

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/api/crafting/recipe/PressureChamberRecipe.java
+++ b/src/main/java/me/desht/pneumaticcraft/api/crafting/recipe/PressureChamberRecipe.java
@@ -70,22 +70,28 @@ public abstract class PressureChamberRecipe extends PneumaticCraftRecipe {
     }
 
     /**
-     * Get the slot groups that are synchronized with each other.
+     * Get the slots that are synchronized with each other.
      * They must have the same cycle length and not intersect.
+     * <p>
+     * A sync group (represented by a set of {@link RecipeSlot}s) will have all its member's cycles synchronized
+     * should one of the members be the focus for a recipe lookup.
+     * <p>
+     * If you need more functionality, see {@link PressureChamberRecipe#getSyncForDisplay(SlotCycle)}.
      *
-     * @return List of slot groups
-     * @see PressureChamberRecipe#getSyncForDisplay(SlotCycle)
+     * @return List of sync groups represented by a set of {@link RecipeSlot}s
      */
     protected List<Set<RecipeSlot>> getSyncGroupsForDisplay() {
         return ImmutableList.of();
     }
 
     /**
-     * Get the slots that are synchronized with the given slot.
+     * Get the slots and associated cycles that are synchronized with the given focused slot and matched cycle indices.
      * Prefer overriding {@link PressureChamberRecipe#getSyncGroupsForDisplay()} unless you need special handling.
+     * <p>
+     * This method is called when a recipe lookup is done through JEI that has a focus.
      *
-     * @param focusedSlotCycle target slot
-     * @return synchronizations for the given slot
+     * @param focusedSlotCycle Slot and indices of the slot's cycle that matches with the focus
+     * @return Synchronizations for the given slot cycle
      */
     public Map<RecipeSlot, List<Integer>> getSyncForDisplay(SlotCycle focusedSlotCycle) {
         RecipeSlot focusedSlot = focusedSlotCycle.getSlot();
@@ -138,19 +144,34 @@ public abstract class PressureChamberRecipe extends PneumaticCraftRecipe {
         return "";
     }
 
+    /**
+     * Data object for type of slot and the index of the slot.
+     */
     public static final class RecipeSlot {
         private final boolean input;
         private final int index;
 
+        /**
+         * Create a data object to store the type of slot and the index of the slot.
+         *
+         * @param input true iff this is an input slot
+         * @param index index of the slot in the recipe
+         */
         public RecipeSlot(boolean input, int index) {
             this.input = input;
             this.index = index;
         }
 
+        /**
+         * Checks if this is an input slot.
+         */
         public boolean isInput() {
             return input;
         }
 
+        /**
+         * Get the index of the slot.
+         */
         public int getIndex() {
             return index;
         }
@@ -169,19 +190,34 @@ public abstract class PressureChamberRecipe extends PneumaticCraftRecipe {
         }
     }
 
+    /**
+     * Data object for storing a {@link RecipeSlot} and a cycle represented as a list indices for the slot.
+     */
     public static final class SlotCycle {
         private final RecipeSlot slot;
         private final ImmutableList<Integer> cycle;
 
+        /**
+         * Create a data object to store a {@link RecipeSlot} and a cycle represented as a list of indices for the slot.
+         *
+         * @param slot  Type of slot and the index of the slot
+         * @param cycle A cycle represented as a list of indices
+         */
         public SlotCycle(RecipeSlot slot, ImmutableList<Integer> cycle) {
             this.slot = slot;
             this.cycle = cycle;
         }
 
+        /**
+         * Get the {@link RecipeSlot} that this cycle belongs to.
+         */
         public RecipeSlot getSlot() {
             return slot;
         }
 
+        /**
+         * Get the cycle represented as a list of indices.
+         */
         public ImmutableList<Integer> getCycle() {
             return cycle;
         }

--- a/src/main/java/me/desht/pneumaticcraft/api/crafting/recipe/PressureChamberRecipe.java
+++ b/src/main/java/me/desht/pneumaticcraft/api/crafting/recipe/PressureChamberRecipe.java
@@ -1,6 +1,7 @@
 package me.desht.pneumaticcraft.api.crafting.recipe;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.NonNullList;
@@ -10,6 +11,9 @@ import net.minecraftforge.items.IItemHandler;
 import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public abstract class PressureChamberRecipe extends PneumaticCraftRecipe {
     protected PressureChamberRecipe(ResourceLocation id) {
@@ -59,10 +63,41 @@ public abstract class PressureChamberRecipe extends PneumaticCraftRecipe {
      * If overriding and no output slots display more than one stack then can override
      * {@link PressureChamberRecipe#getSingleResultsForDisplay()} instead.
      */
-    public List<? extends List<ItemStack>> getResultsForDisplay() {
+    public List<List<ItemStack>> getResultsForDisplay() {
         return getSingleResultsForDisplay().stream()
                 .map(ImmutableList::of)
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Get the slot groups that are synchronized with each other.
+     * They must have the same cycle length and not intersect.
+     *
+     * @return List of slot groups
+     * @see PressureChamberRecipe#getSyncForDisplay(SlotCycle)
+     */
+    protected List<Set<RecipeSlot>> getSyncGroupsForDisplay() {
+        return ImmutableList.of();
+    }
+
+    /**
+     * Get the slots that are synchronized with the given slot.
+     * Prefer overriding {@link PressureChamberRecipe#getSyncGroupsForDisplay()} unless you need special handling.
+     *
+     * @param focusedSlotCycle target slot
+     * @return synchronizations for the given slot
+     */
+    public Map<RecipeSlot, List<Integer>> getSyncForDisplay(SlotCycle focusedSlotCycle) {
+        RecipeSlot focusedSlot = focusedSlotCycle.getSlot();
+        return getSyncGroupsForDisplay().stream()
+                // Find group that contains the focused slot
+                .filter(set -> set.contains(focusedSlot))
+                .findAny()
+                // Create a mapping from slot to cycle, using the focused slot's cycle
+                .map(set -> set.stream()
+                        .collect(ImmutableMap.toImmutableMap(slot -> slot, slot -> (List<Integer>) focusedSlotCycle.getCycle()))
+                )
+                .orElseGet(ImmutableMap::of);
     }
 
     /**
@@ -101,5 +136,54 @@ public abstract class PressureChamberRecipe extends PneumaticCraftRecipe {
      */
     public String getTooltipKey(boolean input, int slot) {
         return "";
+    }
+
+    public static final class RecipeSlot {
+        private final boolean input;
+        private final int index;
+
+        public RecipeSlot(boolean input, int index) {
+            this.input = input;
+            this.index = index;
+        }
+
+        public boolean isInput() {
+            return input;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            RecipeSlot that = (RecipeSlot) o;
+            return input == that.input && index == that.index;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(input, index);
+        }
+    }
+
+    public static final class SlotCycle {
+        private final RecipeSlot slot;
+        private final ImmutableList<Integer> cycle;
+
+        public SlotCycle(RecipeSlot slot, ImmutableList<Integer> cycle) {
+            this.slot = slot;
+            this.cycle = cycle;
+        }
+
+        public RecipeSlot getSlot() {
+            return slot;
+        }
+
+        public ImmutableList<Integer> getCycle() {
+            return cycle;
+        }
     }
 }

--- a/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureChamberRecipeImpl.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureChamberRecipeImpl.java
@@ -77,7 +77,7 @@ public class PressureChamberRecipeImpl extends PressureChamberRecipe {
     }
 
     @Override
-    public NonNullList<ItemStack> getResultsForDisplay() {
+    protected List<ItemStack> getSingleResultsForDisplay() {
         return outputs;
     }
 
@@ -109,7 +109,7 @@ public class PressureChamberRecipeImpl extends PressureChamberRecipe {
 
     @Nonnull
     @Override
-    public NonNullList<ItemStack> craftRecipe(@Nonnull IItemHandler chamberHandler, List<Integer> ingredientSlots) {
+    public NonNullList<ItemStack> craftRecipe(@Nonnull IItemHandler chamberHandler, List<Integer> ingredientSlots, boolean simulate) {
         // remove the recipe's input items from the chamber
         for (Ingredient ingredient : inputs) {
             if (ingredient.hasNoMatchingItems()) return NonNullList.create(); // sanity check
@@ -117,7 +117,7 @@ public class PressureChamberRecipeImpl extends PressureChamberRecipe {
             for (int i = 0; i < ingredientSlots.size() && nItems > 0; i++) {
                 int slot = ingredientSlots.get(i);
                 if (ingredient.test(chamberHandler.getStackInSlot(slot))) {
-                    ItemStack extracted = chamberHandler.extractItem(slot, nItems, false);
+                    ItemStack extracted = chamberHandler.extractItem(slot, nItems, simulate);
                     nItems -= extracted.getCount();
                 }
             }

--- a/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureDisenchantingRecipe.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureDisenchantingRecipe.java
@@ -2,6 +2,7 @@ package me.desht.pneumaticcraft.common.recipes.machine;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import me.desht.pneumaticcraft.common.core.ModRecipes;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -87,13 +88,21 @@ public class PressureDisenchantingRecipe extends PressureChamberRecipeImpl {
     }
 
     @Override
-    public List<? extends List<ItemStack>> getResultsForDisplay() {
+    public List<List<ItemStack>> getResultsForDisplay() {
         ItemStack pick = new ItemStack(Items.DIAMOND_PICKAXE);
         ItemStack enchantedBook = new ItemStack(Items.ENCHANTED_BOOK);
         enchantedBook.addEnchantment(Enchantments.EFFICIENCY, 1);
         ItemStack resultBook = new ItemStack(Items.ENCHANTED_BOOK);
         resultBook.addEnchantment(Enchantments.FORTUNE, 1);
         return ImmutableList.of(ImmutableList.of(pick, enchantedBook), ImmutableList.of(resultBook));
+    }
+
+    @Override
+    public List<Set<RecipeSlot>> getSyncGroupsForDisplay() {
+        return ImmutableList.of(ImmutableSet.of(
+                new RecipeSlot(true, 0),
+                new RecipeSlot(false, 0)
+        ));
     }
 
     @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureDisenchantingRecipe.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureDisenchantingRecipe.java
@@ -38,8 +38,11 @@ public class PressureDisenchantingRecipe extends PressureChamberRecipeImpl {
             ItemStack stack = chamberHandler.getStackInSlot(i);
             if (stack.getItem() == Items.BOOK) {
                 bookSlot = i;
-            } else if (stack.getItem() != Items.ENCHANTED_BOOK && EnchantmentHelper.getEnchantments(stack).size() > 0) {
-                itemSlot = i;
+            } else {
+                int minEnchantments = stack.getItem() == Items.ENCHANTED_BOOK ? 2 : 1;
+                if (EnchantmentHelper.getEnchantments(stack).size() >= minEnchantments) {
+                    itemSlot = i;
+                }
             }
             if (bookSlot >= 0 && itemSlot >= 0) return ImmutableList.of(bookSlot, itemSlot);
         }
@@ -59,6 +62,10 @@ public class PressureDisenchantingRecipe extends PressureChamberRecipeImpl {
         Enchantment strippedEnchantment = l.get(new Random().nextInt(l.size()));
         int level = enchantments.get(strippedEnchantment);
         enchantments.remove(strippedEnchantment);
+        // Workaround for setEnchantments on an Enchanted Book merging enchantments instead of setting them
+        if (enchantedStack.getItem() == Items.ENCHANTED_BOOK) {
+            enchantedStack = new ItemStack(Items.ENCHANTED_BOOK);
+        }
         EnchantmentHelper.setEnchantments(enchantments, enchantedStack);
 
         // ...and create an enchanted book with it

--- a/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureDisenchantingRecipe.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureDisenchantingRecipe.java
@@ -50,9 +50,9 @@ public class PressureDisenchantingRecipe extends PressureChamberRecipeImpl {
     }
 
     @Override
-    public NonNullList<ItemStack> craftRecipe(@Nonnull IItemHandler chamberHandler, List<Integer> ingredientSlots) {
-        ItemStack book = chamberHandler.extractItem(ingredientSlots.get(0), 1, false);
-        ItemStack enchantedStack = chamberHandler.extractItem(ingredientSlots.get(1), 1, false);
+    public NonNullList<ItemStack> craftRecipe(@Nonnull IItemHandler chamberHandler, List<Integer> ingredientSlots, boolean simulate) {
+        ItemStack book = chamberHandler.extractItem(ingredientSlots.get(0), 1, simulate);
+        ItemStack enchantedStack = chamberHandler.extractItem(ingredientSlots.get(1), 1, simulate);
 
         if (book.isEmpty() || enchantedStack.isEmpty()) return NonNullList.create();
 
@@ -79,16 +79,21 @@ public class PressureDisenchantingRecipe extends PressureChamberRecipeImpl {
     public List<Ingredient> getInputsForDisplay() {
         ItemStack pick = new ItemStack(Items.DIAMOND_PICKAXE);
         pick.addEnchantment(Enchantments.FORTUNE, 1);
+        ItemStack enchantedBook = new ItemStack(Items.ENCHANTED_BOOK);
+        enchantedBook.addEnchantment(Enchantments.FORTUNE, 1);
+        enchantedBook.addEnchantment(Enchantments.EFFICIENCY, 1);
 
-        return ImmutableList.of(Ingredient.fromStacks(pick), Ingredient.fromItems(Items.BOOK));
+        return ImmutableList.of(Ingredient.fromStacks(pick, enchantedBook), Ingredient.fromItems(Items.BOOK));
     }
 
     @Override
-    public NonNullList<ItemStack> getResultsForDisplay() {
+    public List<? extends List<ItemStack>> getResultsForDisplay() {
         ItemStack pick = new ItemStack(Items.DIAMOND_PICKAXE);
-        ItemStack book = new ItemStack(Items.ENCHANTED_BOOK);
-        book.addEnchantment(Enchantments.FORTUNE, 1);
-        return NonNullList.from(ItemStack.EMPTY, pick, book);
+        ItemStack enchantedBook = new ItemStack(Items.ENCHANTED_BOOK);
+        enchantedBook.addEnchantment(Enchantments.EFFICIENCY, 1);
+        ItemStack resultBook = new ItemStack(Items.ENCHANTED_BOOK);
+        resultBook.addEnchantment(Enchantments.FORTUNE, 1);
+        return ImmutableList.of(ImmutableList.of(pick, enchantedBook), ImmutableList.of(resultBook));
     }
 
     @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureEnchantingRecipe.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/recipes/machine/PressureEnchantingRecipe.java
@@ -66,7 +66,7 @@ public class PressureEnchantingRecipe extends PressureChamberRecipeImpl {
     }
 
     @Override
-    public NonNullList<ItemStack> craftRecipe(@Nonnull IItemHandler chamberHandler, List<Integer> ingredientSlots) {
+    public NonNullList<ItemStack> craftRecipe(@Nonnull IItemHandler chamberHandler, List<Integer> ingredientSlots, boolean simulate) {
         ItemStack enchantedBook = chamberHandler.getStackInSlot(ingredientSlots.get(0));
         ItemStack enchantable = chamberHandler.getStackInSlot(ingredientSlots.get(1)).copy();
 
@@ -91,8 +91,8 @@ public class PressureEnchantingRecipe extends PressureChamberRecipeImpl {
             bookEnchantments.forEach(newBook::addEnchantment);
         }
 
-        chamberHandler.extractItem(ingredientSlots.get(0), 1, false);
-        chamberHandler.extractItem(ingredientSlots.get(1), 1, false);
+        chamberHandler.extractItem(ingredientSlots.get(0), 1, simulate);
+        chamberHandler.extractItem(ingredientSlots.get(1), 1, simulate);
         return NonNullList.from(ItemStack.EMPTY, newBook, enchantable);
     }
 
@@ -105,7 +105,7 @@ public class PressureEnchantingRecipe extends PressureChamberRecipeImpl {
     }
 
     @Override
-    public NonNullList<ItemStack> getResultsForDisplay() {
+    public List<ItemStack> getSingleResultsForDisplay() {
         ItemStack pick = new ItemStack(Items.DIAMOND_PICKAXE);
         pick.addEnchantment(Enchantments.FORTUNE, 1);
         ItemStack book = new ItemStack(Items.BOOK);

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/patchouli/ProcessorPressureChamber.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/patchouli/ProcessorPressureChamber.java
@@ -1,14 +1,18 @@
 package me.desht.pneumaticcraft.common.thirdparty.patchouli;
 
+import com.google.common.collect.ImmutableList;
 import me.desht.pneumaticcraft.api.crafting.recipe.PressureChamberRecipe;
 import me.desht.pneumaticcraft.common.recipes.PneumaticCraftRecipeType;
 import me.desht.pneumaticcraft.common.util.PneumaticCraftUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import vazkii.patchouli.api.IComponentProcessor;
 import vazkii.patchouli.api.IVariable;
 import vazkii.patchouli.api.IVariableProvider;
+
+import java.util.List;
 
 @SuppressWarnings("unused")
 public class ProcessorPressureChamber implements IComponentProcessor {
@@ -35,8 +39,9 @@ public class ProcessorPressureChamber implements IComponentProcessor {
             }
         } else if (s.startsWith("output")) {
             int index = Integer.parseInt(s.substring(6)) - 1;
-            if (index >= 0 && index < recipe.getResultsForDisplay().size()) {
-                return IVariable.from(recipe.getResultsForDisplay().get(index));
+            List<? extends List<ItemStack>> results = recipe.getResultsForDisplay();
+            if (index >= 0 && index < results.size()) {
+                return IVariable.wrapList(results.get(index).stream().map(IVariable::from).collect(ImmutableList.toImmutableList()));
             }
         } else if (s.equals("pressure")) {
             String pr = PneumaticCraftUtils.roundNumberTo(recipe.getCraftingPressure(), 1);
@@ -48,10 +53,13 @@ public class ProcessorPressureChamber implements IComponentProcessor {
 
     private String defaultHeader() {
         // note: only returns first item. use a custom "header" if needed
-        if (!recipe.getResultsForDisplay().isEmpty()) {
-            return recipe.getResultsForDisplay().get(0).getDisplayName().getString();
-        } else {
-            return "";
+        List<? extends List<ItemStack>> results = recipe.getResultsForDisplay();
+        if (!results.isEmpty()) {
+            List<ItemStack> stacks = results.get(0);
+            if (!stacks.isEmpty()) {
+                return stacks.get(0).getDisplayName().getString();
+            }
         }
+        return "";
     }
 }

--- a/src/main/java/me/desht/pneumaticcraft/common/tileentity/TileEntityPressureChamberValve.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/tileentity/TileEntityPressureChamberValve.java
@@ -300,7 +300,7 @@ public class TileEntityPressureChamberValve extends TileEntityPneumaticBase
             if (pressureOK) {
                 // let's craft! (although if the output handler is full, we won't...)
                 isSufficientPressureInChamber = true;
-                if (giveOutput(recipe.getResultsForDisplay(), true) && giveOutput(recipe.craftRecipe(itemsInChamber, applicableRecipe.slots), false)) {
+                if (giveOutput(recipe.craftRecipe(itemsInChamber, applicableRecipe.slots, true), true) && giveOutput(recipe.craftRecipe(itemsInChamber, applicableRecipe.slots, false), false)) {
                     if (getWorld().getGameTime() - lastSoundTick > 5) {
                         getWorld().playSound(null, getPos(), SoundEvents.ENTITY_CHICKEN_EGG, SoundCategory.BLOCKS, 0.7f, 0.8f);
                         lastSoundTick = getWorld().getGameTime();

--- a/src/main/resources/data/pneumaticcraft/patchouli_books/book/en_us/entries/machines/vacuum_pump.json
+++ b/src/main/resources/data/pneumaticcraft/patchouli_books/book/en_us/entries/machines/vacuum_pump.json
@@ -17,7 +17,7 @@
     {
       "type": "text",
       "title": "Applications",
-      "text": "The following uses exist for negative (vacuum) pressure:$(li)Disenchanting: place an $(item)enchanted item/$ and a vanilla $(item)Book/$ in a $(l:manufacturing/pressure_chamber)Pressure Chamber/$ and give the chamber sufficient negative pressure. A random enchantment will transfer from the item to the book.$(li)The $(l:tubes/air_grate_module)Air Grate Module/$, when given negative pressure, will attract entities to itself."
+      "text": "The following uses exist for negative (vacuum) pressure:$(li)Disenchanting: place an $(item)enchanted item/$ or $(item)Enchanted Book/$ with more than one enchantment and a vanilla $(item)Book/$ in a $(l:manufacturing/pressure_chamber)Pressure Chamber/$ and give the chamber sufficient negative pressure. A random enchantment will transfer from the item to the book.$(li)The $(l:tubes/air_grate_module)Air Grate Module/$, when given negative pressure, will attract entities to itself."
     },
     {
       "type": "text",
@@ -28,6 +28,11 @@
       "type": "crafting",
       "text": "Creating a Vacuum Pump",
       "recipe": "pneumaticcraft:vacuum_pump"
+    },
+    {
+      "type": "pneumaticcraft:pressure_chamber",
+      "header": "Vacuum Disenchanting",
+      "recipe": "pneumaticcraft:pressure_chamber/pressure_chamber_disenchanting"
     }
   ]
 }


### PR DESCRIPTION
Changes in PR:
- Add Enchanted Book support to `PressureDisenchantingRecipe`
- Changed `PressureChamberRecipe#craftRecipe` to allow for simulation, to try decouple it from `PressureChamberRecipe#getResultsForDisplay`
- Changed `PressureChamberRecipe#getResultsForDisplay` to support multiple display stacks per slot which is now used for JEI and Patchouli only afaict (added `protected PressureChamberRecipe#getSingleResultsForDisplay` for simple recipes usage)
- Updated the Patchouli book's Vacuum Pump entry to state that it can also Disenchant Enchanted Books with more than one enchantment and also added a page to the end of the entry to show the recipe.

Went down quite a rabbit hole working out how to get multiple display stacks to work properly.
The change to craftRecipe to allow for simulation might have problems with the randomly removed enchantment may cause some problems if there's some kinda stackable enchanted item but I think this was already the case.

[Video](https://www.youtube.com/watch?v=vOgMwP75rJ4) (2m) showing this PR with timestamps.

Implements suggestion https://github.com/TeamPneumatic/pnc-repressurized/issues/425