### PR TITLE
Fixed permafrost block_heat_properties typo

### DIFF
--- a/src/main/resources/data/pneumaticcraft/recipes/block_heat_properties/quark/permafrost.json
+++ b/src/main/resources/data/pneumaticcraft/recipes/block_heat_properties/quark/permafrost.json
@@ -3,7 +3,7 @@
   "block": "quark:permafrost",
   "temperature": 223,
   "heatCapacity": 5000,
-  "transformCold": {
+  "transformHot": {
     "block": "minecraft:cobblestone"
   }
 }


### PR DESCRIPTION
At the moment Permafrost is converted to Cobblestone when it's cooled, eventhough it's a cold block. I'm fairly certain it's supposed to be heated to Cobblestone.

Originally reported here: https://github.com/NillerMedDild/Enigmatica6/issues/3055