### PR TITLE
Heat Sink now uses Vanilla Freezing effect and damage

### DIFF
--- a/src/api/java/me/desht/pneumaticcraft/api/DamageSourcePneumaticCraft.java
+++ b/src/api/java/me/desht/pneumaticcraft/api/DamageSourcePneumaticCraft.java
@@ -24,6 +24,11 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 
 public class DamageSourcePneumaticCraft extends DamageSource {
+    /**
+     * {@code @Deprecated} Will be removed in 1.19 in favor of Vanilla Freeze Damage Source
+     */
+    @Deprecated(forRemoval = true)
+    public static final DamageSource FREEZING = DamageSource.FREEZE;
     public static final DamageSource PRESSURE = new DamageSourcePneumaticCraft("pressure", 2).bypassArmor();
     public static final DamageSource ETCHING_ACID = new DamageSourcePneumaticCraft("acid", 2);
     public static final DamageSource SECURITY_STATION = new DamageSourcePneumaticCraft("securityStation").bypassArmor();

--- a/src/api/java/me/desht/pneumaticcraft/api/DamageSourcePneumaticCraft.java
+++ b/src/api/java/me/desht/pneumaticcraft/api/DamageSourcePneumaticCraft.java
@@ -27,7 +27,6 @@ public class DamageSourcePneumaticCraft extends DamageSource {
     public static final DamageSource PRESSURE = new DamageSourcePneumaticCraft("pressure", 2).bypassArmor();
     public static final DamageSource ETCHING_ACID = new DamageSourcePneumaticCraft("acid", 2);
     public static final DamageSource SECURITY_STATION = new DamageSourcePneumaticCraft("securityStation").bypassArmor();
-    public static final DamageSource FREEZING = new DamageSourcePneumaticCraft("freezing", 2);
     public static final DamageSource PLASTIC_BLOCK = new DamageSourcePneumaticCraft("plastic_block", 2);
 
     public static boolean isDroneOverload(DamageSource src) {

--- a/src/main/resources/assets/pneumaticcraft/lang/en_us.json
+++ b/src/main/resources/assets/pneumaticcraft/lang/en_us.json
@@ -785,8 +785,6 @@
    "pneumaticcraft.command.globalVariable.prefixReminder" : "No prefix used, assuming player-global. Use '#' for player-global, '%' for server-global.",
    "pneumaticcraft.death.attack.acid1" : "%1$s was etched to death!",
    "pneumaticcraft.death.attack.acid2" : "%1$s turned into a PCB!",
-   "pneumaticcraft.death.attack.freezing1" : "%1$s froze to death!",
-   "pneumaticcraft.death.attack.freezing2" : "%1$s got a bit too cool!",
    "pneumaticcraft.death.attack.plastic_block1" : "%1$s stepped on something unreasonably painful!",
    "pneumaticcraft.death.attack.plastic_block2" : "%1$s should have worn some footwear!",
    "pneumaticcraft.death.attack.pressure1" : "%1$s is as flat as a pancake!",


### PR DESCRIPTION
Some improvements to Heat Sink:
- Uses Vanilla freezing instead of damaging directly.
- Uses Vanilla damage type at low temperatures.