### PR TITLE
Add custom shaped recipe type for compressor upgrades

### DIFF
--- a/src/generated/resources/data/pneumaticcraft/recipes/advanced_air_compressor.json
+++ b/src/generated/resources/data/pneumaticcraft/recipes/advanced_air_compressor.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "pneumaticcraft:compressor_upgrade_crafting",
   "key": {
     "C": {
       "item": "pneumaticcraft:air_compressor"

--- a/src/generated/resources/data/pneumaticcraft/recipes/advanced_liquid_compressor.json
+++ b/src/generated/resources/data/pneumaticcraft/recipes/advanced_liquid_compressor.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "pneumaticcraft:compressor_upgrade_crafting",
   "key": {
     "C": {
       "item": "pneumaticcraft:liquid_compressor"

--- a/src/main/java/me/desht/pneumaticcraft/common/core/ModRecipeSerializers.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/core/ModRecipeSerializers.java
@@ -28,6 +28,7 @@ import me.desht.pneumaticcraft.common.recipes.other.FuelQualityRecipeImpl;
 import me.desht.pneumaticcraft.common.recipes.other.HeatPropertiesRecipeImpl;
 import me.desht.pneumaticcraft.common.recipes.special.*;
 import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.item.crafting.SimpleRecipeSerializer;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -100,5 +101,7 @@ public class ModRecipeSerializers {
             = RECIPE_SERIALIZERS.register("crafting_shaped_pressurizable", () -> ShapedPressurizableRecipe.SERIALIZER);
     public static final RegistryObject<ShapedRecipeNoMirror.Serializer> CRAFTING_SHAPED_NO_MIRROR
             = RECIPE_SERIALIZERS.register("crafting_shaped_no_mirror", () -> ShapedRecipeNoMirror.SERIALIZER);
+    public static final RegistryObject<ShapedRecipe.Serializer> COMPRESSOR_UPGRADE_CRAFTING
+            = RECIPE_SERIALIZERS.register("compressor_upgrade_crafting", () -> CompressorUpgradeCrafting.SERIALIZER);
 
 }

--- a/src/main/java/me/desht/pneumaticcraft/common/recipes/special/CompressorUpgradeCrafting.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/recipes/special/CompressorUpgradeCrafting.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of pnc-repressurized.
+ *
+ *     pnc-repressurized is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     pnc-repressurized is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with pnc-repressurized.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.desht.pneumaticcraft.common.recipes.special;
+
+import cofh.lib.util.constants.NBTTags;
+import com.google.common.base.Suppliers;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.TagParser;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.item.crafting.ShapelessRecipe;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jline.utils.Log;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static me.desht.pneumaticcraft.api.PneumaticRegistry.RL;
+
+
+public class CompressorUpgradeCrafting extends ShapedRecipe {
+
+	public static final Serializer SERIALIZER = new Serializer();
+	public static final Supplier<List<Item>> COMPRESSORS = Suppliers.memoize(() -> List.of(
+			getItem("advanced_air_compressor"),
+			getItem("advanced_liquid_compressor"),
+			getItem("air_compressor"),
+			getItem("liquid_compressor")
+	));
+
+	public CompressorUpgradeCrafting(ResourceLocation pId, String pGroup, int pWidth, int pHeight, NonNullList<Ingredient> pRecipeItems, ItemStack pResult) {
+		super(pId, pGroup, pWidth, pHeight, pRecipeItems, pResult);
+	}
+
+	private static Item getItem(String id) {
+		return ForgeRegistries.ITEMS.getValue(RL(id));
+	}
+
+	@NotNull
+	@Override
+	public ItemStack assemble(CraftingContainer inv) {
+		ItemStack result = super.assemble(inv);
+
+		int index = getMainItem(inv);
+		if (index == -1) {
+			Log.warn("Just crafted a PNC Compressor upgrade recipe but couldn't find a compressor in the input!");
+			return result;
+		}
+		ItemStack input = inv.getItem(index);
+
+		CompoundTag tag = input.getTag();
+		if (tag == null) return result;
+
+		Tag blockEntityTag = tag.get(NBTTags.TAG_BLOCK_ENTITY);
+		if (blockEntityTag == null) return result;
+
+		result.getOrCreateTag().put(NBTTags.TAG_BLOCK_ENTITY, blockEntityTag);
+		return result;
+	}
+
+	private int getMainItem(CraftingContainer container) {
+		int i;
+		boolean matchFound = false;
+
+		for (i = 0; i < container.getContainerSize(); i++) {
+			ItemStack item = container.getItem(i);
+			if (COMPRESSORS.get().contains(item.getItem())) {
+				matchFound = true;
+				break;
+			}
+		}
+			if (!matchFound) {
+			return -1;
+		}
+		return i;
+	}
+
+	@Override
+	public RecipeSerializer<?> getSerializer() {
+		return SERIALIZER;
+	}
+
+	static class Serializer extends ShapedRecipe.Serializer {
+		@Override
+		public ShapedRecipe fromJson(ResourceLocation pRecipeId, JsonObject pJson) {
+			ShapedRecipe r = super.fromJson(pRecipeId, pJson);
+			return new CompressorUpgradeCrafting(r.getId(), r.getGroup(), r.getRecipeWidth(), r.getRecipeHeight(), r.getIngredients(), r.getResultItem());
+		}
+
+		@Override
+		public ShapedRecipe fromNetwork(ResourceLocation pRecipeId, FriendlyByteBuf pBuffer) {
+			ShapedRecipe r = super.fromNetwork(pRecipeId, pBuffer);
+			return new CompressorUpgradeCrafting(r.getId(), r.getGroup(), r.getRecipeWidth(), r.getRecipeHeight(), r.getIngredients(), r.getResultItem());
+		}
+	}
+}

--- a/src/main/java/me/desht/pneumaticcraft/datagen/ModRecipeProvider.java
+++ b/src/main/java/me/desht/pneumaticcraft/datagen/ModRecipeProvider.java
@@ -9,14 +9,24 @@ import me.desht.pneumaticcraft.api.crafting.ingredient.StackedIngredient;
 import me.desht.pneumaticcraft.api.crafting.recipe.AssemblyRecipe.AssemblyProgramType;
 import me.desht.pneumaticcraft.api.data.PneumaticCraftTags;
 import me.desht.pneumaticcraft.api.item.PNCUpgrade;
-import me.desht.pneumaticcraft.common.core.*;
+import me.desht.pneumaticcraft.common.core.ModBlocks;
+import me.desht.pneumaticcraft.common.core.ModFluids;
+import me.desht.pneumaticcraft.common.core.ModItems;
+import me.desht.pneumaticcraft.common.core.ModRecipeSerializers;
+import me.desht.pneumaticcraft.common.core.ModUpgrades;
 import me.desht.pneumaticcraft.common.recipes.FluidTagPresentCondition;
 import me.desht.pneumaticcraft.common.util.PlayerFilter;
 import me.desht.pneumaticcraft.common.util.PneumaticCraftUtils;
 import me.desht.pneumaticcraft.datagen.recipe.*;
 import me.desht.pneumaticcraft.lib.ModIds;
 import net.minecraft.data.DataGenerator;
-import net.minecraft.data.recipes.*;
+import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.ShapedRecipeBuilder;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
+import net.minecraft.data.recipes.SimpleCookingRecipeBuilder;
+import net.minecraft.data.recipes.SingleItemRecipeBuilder;
+import net.minecraft.data.recipes.SpecialRecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
@@ -61,14 +71,14 @@ public class ModRecipeProvider extends RecipeProvider {
                 'R', Tags.Items.DUSTS_REDSTONE
         ).save(consumer);
 
-        shaped(ModBlocks.ADVANCED_AIR_COMPRESSOR.get(), ModBlocks.ADVANCED_PRESSURE_TUBE.get(),
+        shapedCompressorUpgrade(ModBlocks.ADVANCED_AIR_COMPRESSOR.get(), ModBlocks.ADVANCED_PRESSURE_TUBE.get(),
                 "III/I T/ICI",
                 'I', PneumaticCraftTags.Items.INGOTS_COMPRESSED_IRON,
                 'T', ModBlocks.ADVANCED_PRESSURE_TUBE.get(),
                 'C', ModBlocks.AIR_COMPRESSOR.get()
         ).save(consumer);
 
-        shaped(ModBlocks.ADVANCED_LIQUID_COMPRESSOR.get(), ModBlocks.ADVANCED_PRESSURE_TUBE.get(),
+        shapedCompressorUpgrade(ModBlocks.ADVANCED_LIQUID_COMPRESSOR.get(), ModBlocks.ADVANCED_PRESSURE_TUBE.get(),
                 "III/ITT/ICI",
                 'I', PneumaticCraftTags.Items.INGOTS_COMPRESSED_IRON,
                 'T', ModBlocks.ADVANCED_PRESSURE_TUBE.get(),
@@ -1684,6 +1694,10 @@ public class ModRecipeProvider extends RecipeProvider {
         builder.unlockedBy("has_" + safeName(required), has(required));
         return builder;
     }
+
+    private <T extends ItemLike> CompressorUpgradeRecipeBuilder shapedCompressorUpgrade(T result, T required, String pattern, Object... keys) {
+        return genericShaped(CompressorUpgradeRecipeBuilder.shapedRecipe(result), result, required, pattern, keys);
+    };
 
     private <T extends ItemLike> ShapedPressurizableRecipeBuilder shapedPressure(T result, T required, String pattern, Object... keys) {
         return genericShaped(ShapedPressurizableRecipeBuilder.shapedRecipe(result), result, required, pattern, keys);

--- a/src/main/java/me/desht/pneumaticcraft/datagen/recipe/CompressorUpgradeRecipeBuilder.java
+++ b/src/main/java/me/desht/pneumaticcraft/datagen/recipe/CompressorUpgradeRecipeBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of pnc-repressurized.
+ *
+ *     pnc-repressurized is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     pnc-repressurized is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with pnc-repressurized.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.desht.pneumaticcraft.datagen.recipe;
+
+import me.desht.pneumaticcraft.common.core.ModRecipeSerializers;
+import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.data.recipes.ShapedRecipeBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.ItemLike;
+
+import java.util.function.Consumer;
+
+public class CompressorUpgradeRecipeBuilder extends ShapedRecipeBuilder {
+	public CompressorUpgradeRecipeBuilder(ItemLike pResult, int pCount) {
+		super(pResult, pCount);
+	}
+
+    public static CompressorUpgradeRecipeBuilder shapedRecipe(ItemLike resultIn) {
+        return shapedRecipe(resultIn, 1);
+    }
+
+    public static CompressorUpgradeRecipeBuilder shapedRecipe(ItemLike resultIn, int countIn) {
+        return new CompressorUpgradeRecipeBuilder(resultIn, countIn);
+    }
+
+    public void save(Consumer<FinishedRecipe> consumerIn, ResourceLocation id) {
+        Consumer<FinishedRecipe> c = (finishedRecipe) -> consumerIn.accept(new WrappedBuilderResult(finishedRecipe, ModRecipeSerializers.COMPRESSOR_UPGRADE_CRAFTING));
+        super.save(c, id);
+    }
+}


### PR DESCRIPTION
It copies the blocks NBT tags (air, upgrades, inventories) to the output compressor, so nothing is lost.

Fixes #1157

Theoretically there could still be losses if a modpack makes the recipe require two of the previous compressor, but I don't believe that to matter enough to attempt to combine the tags.
There could also be a dupe bug if a modpack makes the recipe output multiple, but again I don't think that it is worth the effort trying to split the contents evenly between however many outputs there are. (If you are someone in the future reading this, just use a traditional shaped recipe)