### PR TITLE
add support for custom PCBs

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/block/entity/EtchingTankBlockEntity.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/entity/EtchingTankBlockEntity.java
@@ -152,10 +152,8 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
                 } else {
                     itemIdStr = itemIdStr.replace("_empty_pcb", "");
                     itemIdStr += "_unassembled_pcb";
-                    String outputId = modId + ":" + itemIdStr;
                     ResourceLocation outputResourceLocation = new ResourceLocation(modId, itemIdStr);
                     Item item = ForgeRegistries.ITEMS.getValue(outputResourceLocation);
-                    Log.info("custom pcb " + outputId);
                     excess = outputHandler.insertItem(0, new ItemStack(Objects.requireNonNullElseGet(item, ModItems.UNASSEMBLED_PCB)), false);
                 }
             } else {
@@ -164,10 +162,8 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
                 } else {
                     itemIdStr = itemIdStr.replace("_empty_pcb", "");
                     itemIdStr += "_failed_pcb";
-                    String outputId = modId + ":" + itemIdStr;
                     ResourceLocation outputResourceLocation = new ResourceLocation(modId, itemIdStr);
                     Item item = ForgeRegistries.ITEMS.getValue(outputResourceLocation);
-                    Log.info("custom pcb " + outputId);
                     excess = failedHandler.insertItem(0, new ItemStack(Objects.requireNonNullElseGet(item, ModItems.FAILED_PCB)), false);
                 }
             }
@@ -293,7 +289,7 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return stack.getItem() == ModItems.UNASSEMBLED_PCB.get();
+            return Objects.requireNonNull(ForgeRegistries.ITEMS.getKey(stack.getItem())).toString().contains("unassembled_pcb");
         }
     }
 
@@ -304,7 +300,7 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return stack.getItem() == ModItems.FAILED_PCB.get();
+            return Objects.requireNonNull(ForgeRegistries.ITEMS.getKey(stack.getItem())).toString().contains("failed_pcb");
         }
     }
 

--- a/src/main/java/me/desht/pneumaticcraft/common/block/entity/EtchingTankBlockEntity.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/entity/EtchingTankBlockEntity.java
@@ -247,7 +247,7 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-            return stack.getItem() == ModItems.EMPTY_PCB.get() && UVLightBoxBlockEntity.getExposureProgress(stack) > 0;
+            return stack.getItem() instanceof EmptyPCBItem && UVLightBoxBlockEntity.getExposureProgress(stack) > 0;
         }
 
         @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/block/entity/EtchingTankBlockEntity.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/entity/EtchingTankBlockEntity.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import me.desht.pneumaticcraft.api.PneumaticRegistry;
 import me.desht.pneumaticcraft.api.data.PneumaticCraftTags;
 import me.desht.pneumaticcraft.api.heat.IHeatExchangerLogic;
+import me.desht.pneumaticcraft.api.lib.Names;
 import me.desht.pneumaticcraft.common.core.ModBlockEntities;
 import me.desht.pneumaticcraft.common.core.ModItems;
 import me.desht.pneumaticcraft.common.inventory.EtchingTankMenu;
@@ -147,7 +148,7 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
             String itemIdStr = itemId.getPath();
             String modId = itemId.getNamespace();
             if (success) {
-                if (itemIdStr.startsWith("empty_")) {
+                if (modId.equals(Names.MOD_ID)) {
                     excess = outputHandler.insertItem(0, new ItemStack(ModItems.UNASSEMBLED_PCB.get()), false);
                 } else {
                     itemIdStr = itemIdStr.replace("_empty_pcb", "");
@@ -157,7 +158,7 @@ public class EtchingTankBlockEntity extends AbstractTickingBlockEntity
                     excess = outputHandler.insertItem(0, new ItemStack(Objects.requireNonNullElseGet(item, ModItems.UNASSEMBLED_PCB)), false);
                 }
             } else {
-                if (itemIdStr.startsWith("empty_")) {
+                if (modId.equals(Names.MOD_ID)) {
                     excess = failedHandler.insertItem(0, new ItemStack(ModItems.FAILED_PCB.get()), false);
                 } else {
                     itemIdStr = itemIdStr.replace("_empty_pcb", "");

--- a/src/main/java/me/desht/pneumaticcraft/common/inventory/EtchingTankMenu.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/inventory/EtchingTankMenu.java
@@ -22,6 +22,7 @@ import me.desht.pneumaticcraft.common.block.entity.UVLightBoxBlockEntity;
 import me.desht.pneumaticcraft.common.core.ModItems;
 import me.desht.pneumaticcraft.common.core.ModMenuTypes;
 import me.desht.pneumaticcraft.common.inventory.slot.OutputOnlySlot;
+import me.desht.pneumaticcraft.common.item.EmptyPCBItem;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -59,7 +60,7 @@ public class EtchingTankMenu extends AbstractPneumaticCraftMenu<EtchingTankBlock
 
         @Override
         public boolean mayPlace(@Nonnull ItemStack stack) {
-            return stack.getItem() == ModItems.EMPTY_PCB.get() && UVLightBoxBlockEntity.getExposureProgress(stack) > 0;
+            return stack.getItem() instanceof EmptyPCBItem && UVLightBoxBlockEntity.getExposureProgress(stack) > 0;
         }
 
         @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/inventory/UVLightBoxMenu.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/inventory/UVLightBoxMenu.java
@@ -59,7 +59,7 @@ public class UVLightBoxMenu extends AbstractPneumaticCraftMenu<UVLightBoxBlockEn
 
         @Override
         public boolean mayPlace(@Nonnull ItemStack stack) {
-            return stack.getItem() == ModItems.EMPTY_PCB.get() && EmptyPCBItem.getEtchProgress(stack) == 0;
+            return stack.getItem() instanceof EmptyPCBItem && EmptyPCBItem.getEtchProgress(stack) == 0;
         }
 
         @Override

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/jei/JEIEtchingTankCategory.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/jei/JEIEtchingTankCategory.java
@@ -17,10 +17,13 @@
 
 package me.desht.pneumaticcraft.common.thirdparty.jei;
 
+import me.desht.pneumaticcraft.PneumaticCraftRepressurized;
+import me.desht.pneumaticcraft.api.lib.Names;
 import me.desht.pneumaticcraft.common.block.entity.UVLightBoxBlockEntity;
 import me.desht.pneumaticcraft.common.core.ModBlocks;
 import me.desht.pneumaticcraft.common.core.ModFluids;
 import me.desht.pneumaticcraft.common.core.ModItems;
+import me.desht.pneumaticcraft.common.item.EmptyPCBItem;
 import me.desht.pneumaticcraft.lib.Textures;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
@@ -31,12 +34,17 @@ import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static me.desht.pneumaticcraft.common.util.PneumaticCraftUtils.xlate;
 
@@ -71,17 +79,41 @@ public class JEIEtchingTankCategory extends AbstractPNCCategory<JEIEtchingTankCa
     }
 
     static List<EtchingTankRecipe> getAllRecipes() {
-        ItemStack[] input = new ItemStack[4];
-        for (int i = 0; i < input.length; i++) {
-            input[i] = new ItemStack(ModItems.EMPTY_PCB.get());
-            UVLightBoxBlockEntity.setExposureProgress(input[i], 25 + 25 * i);
+        List<EtchingTankRecipe> recipes = new ArrayList<>();
+        for (Item item : ForgeRegistries.ITEMS.getValues()) {
+            ResourceLocation itemId = Objects.requireNonNull(ForgeRegistries.ITEMS.getKey(item));
+            String modId = Objects.requireNonNull(ForgeRegistries.ITEMS.getKey(item)).getNamespace();
+            if (item instanceof EmptyPCBItem) {
+                ItemStack[] input = new ItemStack[4];
+                for (int i = 0; i < input.length; i++) {
+                    input[i] = new ItemStack(item);
+                    UVLightBoxBlockEntity.setExposureProgress(input[i], 25 + 25 * i);
+                }
+                ItemStack output;
+                ItemStack failed;
+                if (itemId.getNamespace().equals(Names.MOD_ID)) {
+                    output = new ItemStack(ModItems.UNASSEMBLED_PCB.get());
+                    failed = new ItemStack(ModItems.FAILED_PCB.get());
+                } else {
+                    String itemIdStr = itemId.getPath().replace("_empty_pcb", "");
+                    itemIdStr += "_unassembled_pcb";
+                    ResourceLocation outputResourceLocation = new ResourceLocation(modId, itemIdStr);
+                    Item outputItem = ForgeRegistries.ITEMS.getValue(outputResourceLocation);
+                    output = new ItemStack(Objects.requireNonNullElseGet(outputItem, ModItems.UNASSEMBLED_PCB));
+                    itemIdStr = itemIdStr.replace("_unassembled_pcb", "");
+                    itemIdStr += "_failed_pcb";
+                    ResourceLocation failedResourceLocation = new ResourceLocation(modId, itemIdStr);
+                    Item failedItem = ForgeRegistries.ITEMS.getValue(failedResourceLocation);
+                    failed = new ItemStack(Objects.requireNonNullElseGet(failedItem, ModItems.FAILED_PCB));
+                }
+                recipes.add(new EtchingTankRecipe(
+                        Ingredient.of(input),
+                        output,
+                        failed)
+                );
+            }
         }
-
-        return Collections.singletonList(new EtchingTankRecipe(
-                Ingredient.of(input),
-                new ItemStack(ModItems.UNASSEMBLED_PCB.get()),
-                new ItemStack(ModItems.FAILED_PCB.get()))
-        );
+        return recipes;
     }
 
     // pseudo-recipe

--- a/src/main/java/me/desht/pneumaticcraft/common/thirdparty/jei/JEIUVLightBoxCategory.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/thirdparty/jei/JEIUVLightBoxCategory.java
@@ -20,6 +20,7 @@ package me.desht.pneumaticcraft.common.thirdparty.jei;
 import me.desht.pneumaticcraft.common.block.entity.UVLightBoxBlockEntity;
 import me.desht.pneumaticcraft.common.core.ModBlocks;
 import me.desht.pneumaticcraft.common.core.ModItems;
+import me.desht.pneumaticcraft.common.item.EmptyPCBItem;
 import me.desht.pneumaticcraft.common.recipes.machine.UVLightBoxRecipe;
 import me.desht.pneumaticcraft.lib.Textures;
 import mezz.jei.api.constants.VanillaTypes;
@@ -33,7 +34,9 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,10 +47,18 @@ public class JEIUVLightBoxCategory extends AbstractPNCCategory<UVLightBoxRecipe>
 
     private static final List<UVLightBoxRecipe> UV_LIGHT_BOX_RECIPES;
     static {
-        ItemStack out = new ItemStack(ModItems.EMPTY_PCB.get());
-        UVLightBoxBlockEntity.setExposureProgress(out, 100);
-        UVLightBoxRecipe recipe = new UVLightBoxRecipe(Ingredient.of(ModItems.EMPTY_PCB.get()), out);
-        UV_LIGHT_BOX_RECIPES = Collections.singletonList(recipe);
+        List<UVLightBoxRecipe> recipes = new ArrayList<>();
+        ForgeRegistries.ITEMS.getValues().stream()
+                .filter(item -> item instanceof EmptyPCBItem)
+                .forEach(item -> {
+                    ItemStack out = new ItemStack(item);
+                    ItemStack in = new ItemStack(item);
+                    UVLightBoxBlockEntity.setExposureProgress(out, 100);
+                    UVLightBoxRecipe recipe = new UVLightBoxRecipe(Ingredient.of(in), out);
+                    recipes.add(recipe);
+                });
+        // add recipes to list
+        UV_LIGHT_BOX_RECIPES = Collections.unmodifiableList(recipes);
     }
 
     JEIUVLightBoxCategory() {


### PR DESCRIPTION
The machines for making PCBs are hardcoded to only accept the vanilla empty PCB not any item that is an instance of the EmptyPCBItem class