### PR TITLE
Drone inventory fixes

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/block/entity/SideConfigurator.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/entity/SideConfigurator.java
@@ -116,7 +116,6 @@ public class SideConfigurator<T> {
         int idx = idxMap.get(id);
         ConnectionEntry<T> e = entries.get(idx);
         entries.set(idx, new ConnectionEntry<>(e.id, e.texture, e.cap, handler));
-        setNullFaceHandler(id);
     }
 
     public boolean handleButtonPress(String tag, boolean hasShiftDown) {

--- a/src/main/java/me/desht/pneumaticcraft/common/block/entity/drone/ProgrammableControllerBlockEntity.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/entity/drone/ProgrammableControllerBlockEntity.java
@@ -467,9 +467,8 @@ public class ProgrammableControllerBlockEntity extends AbstractAirHandlingBlockE
 
         ItemStackHandler tmpInv = new ItemStackHandler();
         tmpInv.deserializeNBT(provider, tag.getCompound("droneItems"));
-        for (int i = 0; i < Math.min(tmpInv.getSlots(), droneItemHandler.getSlots()); i++) {
-            droneItemHandler.setStackInSlot(i, tmpInv.getStackInSlot(i).copy());
-        }
+        droneItemHandler.setUseableSlots(tmpInv.getSlots());
+        PneumaticCraftUtils.copyItemHandler(tmpInv, droneItemHandler);
 
         energy.readFromNBT(tag);
 

--- a/src/main/java/me/desht/pneumaticcraft/common/entity/drone/DroneEntity.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/entity/drone/DroneEntity.java
@@ -1154,8 +1154,8 @@ public class DroneEntity extends AbstractDroneEntity implements
 
         ItemStackHandler tmpInv = new ItemStackHandler();
         tmpInv.deserializeNBT(registryAccess(), tag.getCompound("Inventory"));
-        PneumaticCraftUtils.copyItemHandler(tmpInv, droneItemHandler);
         droneItemHandler.setUseableSlots(1 + getUpgrades(ModUpgrades.INVENTORY.get()));
+        PneumaticCraftUtils.copyItemHandler(tmpInv, droneItemHandler);
 
         fluidTank.setCapacity(PneumaticValues.DRONE_TANK_SIZE * (1 + getUpgrades(ModUpgrades.INVENTORY.get())));
         fluidTank.readFromNBT(registryAccess(), tag);


### PR DESCRIPTION
# Fixes:
- Drone & programmable controller inventory not getting fully loaded when inventory upgrades are installed (only the first slot gets loaded)
- Programmable controller's drone inventory "becoming" the programmed item inventory (`nullFaceHandler` wrongly set to the drone inventory instead)

# Video demonstrating the bug:

https://github.com/user-attachments/assets/3b9d90f7-afc7-4e0d-8beb-04fff1ca33be
