### PR TITLE
Fixes a crash caused if you accidentally unselect all sides in an inventory widget.

### DIFF
--- a/src/main/java/me/desht/pneumaticcraft/common/drone/progwidgets/ProgWidgetInventoryBase.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/drone/progwidgets/ProgWidgetInventoryBase.java
@@ -82,6 +82,9 @@ public abstract class ProgWidgetInventoryBase extends ProgWidgetAreaItemBase imp
 
     @Override
     public boolean[] getSides() {
+        if (getAccessingSides().isEmpty()) {
+            return new boolean[6];
+        }
         return decodeSides(getAccessingSides().toByteArray()[0]);
     }
 


### PR DESCRIPTION
I'll add the crash stack I saw in a comment shortly.