### PR TITLE
TPP fix

### DIFF
--- a/src/api/java/me/desht/pneumaticcraft/api/crafting/ingredient/FluidIngredient.java
+++ b/src/api/java/me/desht/pneumaticcraft/api/crafting/ingredient/FluidIngredient.java
@@ -56,7 +56,6 @@ import java.util.stream.Stream;
  * desired fluid.
  */
 public class FluidIngredient extends Ingredient {
-    private List<FluidEntry> fluids;
     private ItemStack[] cachedStacks;
     private final Value[] fluidValues;
 
@@ -67,7 +66,6 @@ public class FluidIngredient extends Ingredient {
 
     private static FluidIngredient empty() {
         FluidIngredient ingr = new FluidIngredient(new Value[0]);
-        ingr.fluids = List.of();
         ingr.cachedStacks = new ItemStack[0];
         return ingr;
     }
@@ -95,13 +93,10 @@ public class FluidIngredient extends Ingredient {
     }
 
     protected List<FluidEntry> getFluidEntryList() {
-        if (fluids == null) {
-            fluids = Arrays.stream(fluidValues)
-                    .flatMap(val -> val.getFluids().stream())
-                    .distinct()
-                    .toList();
-        }
-        return fluids;
+        return Arrays.stream(fluidValues)
+                .flatMap(val -> val.getFluids().stream())
+                .distinct()
+                .toList();
     }
 
     public void fluidToNetwork(FriendlyByteBuf buf) {

--- a/src/api/java/me/desht/pneumaticcraft/api/crafting/recipe/ThermoPlantRecipe.java
+++ b/src/api/java/me/desht/pneumaticcraft/api/crafting/recipe/ThermoPlantRecipe.java
@@ -21,6 +21,7 @@ import me.desht.pneumaticcraft.api.crafting.TemperatureRange;
 import me.desht.pneumaticcraft.api.crafting.ingredient.FluidIngredient;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.material.Fluid;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 import java.util.Optional;
@@ -112,6 +113,10 @@ public abstract class ThermoPlantRecipe extends PneumaticCraftRecipe {
     }
 
     public final boolean testFluid(FluidStack fluid) {
+        return getInputFluid().map(i -> i.testFluid(fluid)).orElse(false);
+    }
+
+    public final boolean testFluid(Fluid fluid) {
         return getInputFluid().map(i -> i.testFluid(fluid)).orElse(false);
     }
 

--- a/src/main/java/me/desht/pneumaticcraft/common/block/entity/processing/ThermoPlantBlockEntity.java
+++ b/src/main/java/me/desht/pneumaticcraft/common/block/entity/processing/ThermoPlantBlockEntity.java
@@ -391,7 +391,7 @@ public class ThermoPlantBlockEntity extends AbstractAirHandlingBlockEntity imple
         public boolean isFluidValid(FluidStack fluid) {
             return fluid.isEmpty() || acceptedFluidCache.isAcceptable(fluid.getFluid(), () ->
                     ModRecipeTypes.THERMO_PLANT.get().stream(level)
-                            .anyMatch(r -> r.value().testFluid(fluid))
+                            .anyMatch(r -> r.value().testFluid(fluid.getFluid()))
             );
         }
 


### PR DESCRIPTION
Two distinct bugs cause the long-standing "Thermopneumatic Processing Plant randomly stops accepting fluid" reports
  (FTBTeam/FTB-Modpack-Issues#5583, FTBTeam/FTB-Modpack-Issues#12146, plus duplicates going back to August 2024). Both are fixed here.

### Bug 1: `FluidIngredient` tag-resolution race

  `FluidIngredient.getFluidEntryList()` lazy-caches the resolved fluid list. `FluidTagValue.getFluids()` resolves via
  `BuiltInRegistries.FLUID.getTagOrEmpty(tag)`. If anything queries the ingredient before the tag binding is committed exactly the scenario commit 9f47efab0 already flagged for the recipe-manager path (*"can happen on server reload if other mods trigger a recipe search via furnace fuel event from tag inspection"*), the list locks in as `[Fluids.EMPTY]` for the lifetime of the recipe instance, and `ThermoPlantBlockEntity.acceptedFluidCache` caches the real fluid as `REJECTED` forever.

I dropped the cache field. Resolution was just a `HashMap` read; `acceptedFluidCache` which short-circuits repeated callers anyway, so the cache wasn't buying much.

  ### Bug 2L `isFluidValid` cache key / tester mismatch

  ```java
  public boolean isFluidValid(FluidStack fluid) {
      return fluid.isEmpty() || acceptedFluidCache.isAcceptable(fluid.getFluid(), () ->
              ModRecipeTypes.THERMO_PLANT.get().stream(level)
                      .anyMatch(r -> r.value().testFluid(fluid))   // FluidStack overload — checks amount!
      );
  }
```

  Cache key is Fluid. Supplier calls testFluid(FluidStack) which includes pushed.amount >= recipe.inputAmount. A probe with amount below the recipe requirement (pipe simulation, partial bucket, LaserIO/SFM poll) returns false -> the fluid type caches as REJECTED-> full-amount pushes are rejected forever, until /reload.

  Vanilla PNC recipes use 100 mB inputs so this rarely trips. Custom modpack recipes with larger amounts (e.g. NeoTech's 5000 mB Purified Virulent Mix -> Crude Oil) get killed by any sub-amount.

  Fix: switched the supplier to testFluid(Fluid) (no-amount overload), added that overload to ThermoPlantRecipe for parity with the API on FluidIngredient. Amount check still happens in runOneCycle via getInputTank().getFluidAmount() <
  currentRecipe.getInputFluidAmount()